### PR TITLE
Fate#319624

### DIFF
--- a/control/control.SLED.xml
+++ b/control/control.SLED.xml
@@ -265,6 +265,11 @@ Please visit us at http://www.suse.com/.
                     <name>default_target</name>
                     <presentation_order>55</presentation_order>
                 </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>65</presentation_order>
+                </proposal_module>
             </proposal_modules>
         </proposal>
 
@@ -317,6 +322,11 @@ Please visit us at http://www.suse.com/.
                 <proposal_module>
                     <name>default_target</name>
                     <presentation_order>55</presentation_order>
+                </proposal_module>
+                <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->
+                <proposal_module>
+                    <name>ssh_import</name>
+                    <presentation_order>65</presentation_order>
                 </proposal_module>
             </proposal_modules>
 

--- a/control/control.SLED.xml
+++ b/control/control.SLED.xml
@@ -53,42 +53,6 @@ textdomain="control"
             </save_instsys_item>
         </save_instsys_content>
 
-        <!-- FATE #305019: configure the files to copy from a previous installation -->
-        <copy_to_system config:type="list">
-            <!-- FATE #300421: Import ssh keys from previous installations -->
-            <copy_to_system_item>
-                <id>import_ssh_keys</id>
-                <copy_to_dir>/</copy_to_dir>
-                <!-- Files that must be all present on the previous system -->
-                <mandatory_files config:type="list">
-                    <file_item>/etc/ssh/ssh_host_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_key.pub</file_item>
-                </mandatory_files>
-                <!-- Files thay may be present -->
-                <optional_files config:type="list">
-                    <file_item>/etc/ssh/ssh_host_dsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_dsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_rsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_rsa_key.pub</file_item>
-                    <file_item>/etc/ssh/ssh_host_ecdsa_key</file_item>
-                    <file_item>/etc/ssh/ssh_host_ecdsa_key.pub</file_item>
-                </optional_files>
-            </copy_to_system_item>
-
-            <!-- FATE #120103: Import Users From Existing Partition -->
-            <copy_to_system_item>
-                <id>import_users</id>
-                <copy_to_dir>/var/lib/YaST2/imported/userdata/</copy_to_dir>
-                <!-- Files that must be all present on the previous system -->
-                <mandatory_files config:type="list">
-                    <file_item>/etc/shadow</file_item>
-                    <file_item>/etc/passwd</file_item>
-                    <file_item>/etc/login.defs</file_item>
-                    <file_item>/etc/group</file_item>
-                </mandatory_files>
-            </copy_to_system_item>
-        </copy_to_system>
-
         <!-- FATE: #304865: Enhance YaST Modules to cooperate better handling the product licenses -->
         <base_product_license_directory>/etc/YaST2/licenses/base/</base_product_license_directory>
 

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed May 18 09:31:22 UTC 2016 - ancor@suse.com
+
+- Removed not longer necessary items from copy_to_system section
+- Added SSH keys import section to the installation proposal
+- Fate#319624
+- 12.0.37
+
+-------------------------------------------------------------------
 Tue Apr  5 16:09:21 UTC 2016 - igonzalezsosa@suse.com
 
 - Automatically update the installer in the initial stage of:

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -84,7 +84,7 @@ Requires:  yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        12.0.36
+Version:        12.0.37
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
Basically a clone of https://github.com/yast/skelcd-control-SLES/pull/60

- Added SSH keys import section to the proposal. See https://github.com/yast/yast-installation/pull/374
- Remove not longer necessary items from the `copy_to_system` section
  - SSH host keys no longer necessary. See https://build.opensuse.org/request/show/396066
  - Users database not longer necessary for user import. See https://build.opensuse.org/request/show/393918