### PR TITLE
Delay autoupgrade self update

### DIFF
--- a/control/control.SLED.xml
+++ b/control/control.SLED.xml
@@ -896,13 +896,6 @@ Please visit us at http://www.suse.com/.
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                 </module>
-                <!-- As soon as possible but after packager is initialized -->
-                <module>
-                    <label>Installer Update</label>
-                    <name>update_installer</name>
-                    <enable_back>yes</enable_back>
-                    <enable_next>yes</enable_next>
-                </module>
                 <module>
                     <label>System for Update</label>
                     <name>update_partition_auto</name>
@@ -915,7 +908,14 @@ Please visit us at http://www.suse.com/.
                     <archs>all</archs>
                     <retranslate config:type="boolean">true</retranslate>
                 </module>
-               <module>
+                <!-- As soon as possible but after packager is initialized -->
+                <module>
+                    <label>Installer Update</label>
+                    <name>update_installer</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
                     <label>AutoYaST Settings</label>
                     <name>autosetup_upgrade</name>
                 </module>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jun 14 15:37:12 UTC 2016 - igonzalezsosa@suse.com
+
+- Delay self-update during autoupgrade until software manager
+  is initialized (bsc#984656)
+- 12.0.41
+
+-------------------------------------------------------------------
 Mon Jun 13 08:40:40 UTC 2016 - igonzalezsosa@suse.com
 
 - Add URL to enable self-update feature (FATE#319716)

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -86,7 +86,7 @@ Requires:  yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        12.0.40
+Version:        12.0.41
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
Fixes second part of [bsc#984656](https://bugzilla.suse.com/show_bug.cgi?id=984656).