### PR TITLE
Run the Inst-sys clean up (bsc#974601)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ functional changes into one commit. When writing commit messages, adhere to
 [widely used
 conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
 
-If your commit is related to a bug in Buzgilla or an issue on GitHub, make sure
+If your commit is related to a bug in Bugzilla or an issue on GitHub, make sure
 you mention it in the commit message for cross-reference. Use format like
 bnc#775814 or gh#yast/yast-foo#42. See also [GitHub
 autolinking](https://help.github.com/articles/github-flavored-markdown#references)

--- a/control/control.SLED.xml
+++ b/control/control.SLED.xml
@@ -575,6 +575,14 @@ Please visit us at http://www.suse.com/.
                     <label>Perform Installation</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <!-- Installation from images -->
                 <module>
                     <label>Perform Installation</label>
@@ -800,6 +808,14 @@ Please visit us at http://www.suse.com/.
                     <label>Perform Update</label>
                     <name>prepdisk</name>
                 </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
+                </module>
                 <module>
                     <label>Perform Update</label>
                     <name>kickoff</name>
@@ -858,6 +874,14 @@ Please visit us at http://www.suse.com/.
                 <module>
                     <label>Perform Installation</label>
                     <name>prepdisk</name>
+                </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
                 </module>
                 <module>
                 <label>Perform Installation</label>
@@ -944,6 +968,14 @@ Please visit us at http://www.suse.com/.
                 <module>
                     <label>Perform Update</label>
                     <name>prepdisk</name>
+                </module>
+                <!-- Clean up the inst-sys to have more free RAM on low memory systems -->
+                <!-- Note: Needs to be call *after* the partitioning step as it might delete
+                the file system or storage kernel modules from inst-sys. They need to be already
+                loaded and active. -->
+                <module>
+                    <label>Installer Cleanup</label>
+                    <name>instsys_cleanup</name>
                 </module>
                 <module>
                     <label>Perform Update</label>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Jul 21 11:30:11 UTC 2016 - lslezak@suse.cz
+
+- Remove some files from the inst-sys to have more free RAM on low
+  memory systems (bsc#974601)
+- 12.2.0
+
+-------------------------------------------------------------------
 Tue Jun 14 15:37:12 UTC 2016 - igonzalezsosa@suse.com
 
 - Delay self-update during autoupgrade until software manager

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -54,6 +54,8 @@ Requires:       yast2-devtools
 Requires:       yast2-fcoe-client
 # For creating the AutoYast profile at the end of installation (bnc#887406)
 Requires:       yast2-firewall
+# instsys_cleanup
+Requires:       yast2-installation >= 3.1.201
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
 Requires:       yast2-multipath


### PR DESCRIPTION
Remove some files from the inst-sys to have more free RAM on low memory systems.

This PR activates the cleaner (https://github.com/yast/yast-installation/pull/407) in the installation/upgrade workflow.

- Version updated to 12.2.0 (to match SP2, it seems we forgot to bump the minor version in SP1...)

The cleaner is called at the initial stage when the inst-sys is running in memory:

- Initial installation
- Upgrade
- Autoinstallation
- Autoupgrade