### PR TITLE
/var/lib/ceph as btrfs subvolume with CoW disabled (bsc#1013011)

### DIFF
--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -76,6 +76,10 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
           <subvolume>
               <path>var/crash</path>
           </subvolume>
+	  <subvolume>
+		<path>var/lib/ceph</path>
+		<copy_on_write config:type="boolean">false</copy_on_write>
+	  </subvolume>
           <subvolume>
               <path>var/lib/libvirt/images</path>
               <copy_on_write config:type="boolean">false</copy_on_write>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  7 19:05:01 UTC 2017 - kmroz@suse.com
+
+- /var/lib/ceph as btrfs subvolume with CoW disabled (bsc#1013011)
+- 15.0.12
+
+-------------------------------------------------------------------
 Wed Nov 29 09:04:06 UTC 2017 - gsouza@suse.com
 
 - Implement system roles for Desktop product (fate#324198)

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -92,7 +92,7 @@ Provides:       system-installation() = SLED
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        15.0.11
+Version:        15.0.12
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
Signed-off-by: Karol Mroz <kmroz@suse.de>