### PR TITLE
Display the product license at upgrade (bsc#1069124)

### DIFF
--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -355,6 +355,12 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                     <enable_next>yes</enable_next>
                 </module>
                 <module>
+                    <label>Product License</label>
+                    <name>product_upgrade_license</name>
+                    <enable_back>yes</enable_back>
+                    <enable_next>yes</enable_next>
+                </module>
+                <module>
                     <name>upgrade_urls</name>
                     <enable_back>yes</enable_back>
                 </module>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 17 13:41:38 UTC 2018 - lslezak@suse.cz
+
+- Display the product license at upgrade (just after selecting
+  the root partition) (bsc#1069124)
+- 15.0.13
+
+-------------------------------------------------------------------
 Tue Dec 12 17:11:12 UTC 2017 - rbrown@suse.com
 
 - adjust subvolume list to have NoCOW /var instead of many 

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -63,6 +63,8 @@ Requires:       yast2-network >= 3.1.24
 Requires:       yast2-nfs-client
 Requires:       yast2-ntp-client
 Requires:       yast2-proxy
+# clients/inst_product_upgrade_license.rb
+Requires:       yast2-packager >= 4.0.29
 Requires:       yast2-services-manager
 Requires:       yast2-configuration-management
 Requires:       yast2-slp
@@ -92,7 +94,7 @@ Provides:       system-installation() = SLED
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        15.0.12
+Version:        15.0.13
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
- Display the license dialog just after selecting the root partition
- See https://bugzilla.suse.com/show_bug.cgi?id=1069124
- 15.0.13