### PR TITLE
Add missing globals

### DIFF
--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -29,15 +29,22 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
   <globals>
     <!-- bsc #1058672: Unset /etc/sysconfig/security/POLKIT_DEFAULT_PRIVS -->
     <polkit_default_privs><![CDATA[]]></polkit_default_privs>
-  </globals>
 
-  <partitioning>
-      <expert_partitioner_warning config:type="boolean">false</expert_partitioner_warning>
+    <!-- FATE #303875, see /etc/sysconfig/network/dhcp:WRITE_HOSTNAME_TO_HOSTS -->
+    <write_hostname_to_hosts config:type="boolean">true</write_hostname_to_hosts>
+    <!-- bnc#870896, see /etc/sysconfig/network/dhcp:DHCLIENT_SET_HOSTNAME -->
+    <dhclient_set_hostname config:type="boolean">false</dhclient_set_hostname>
 
-      <proposal>
-          <lvm config:type="boolean">false</lvm>
-          <proposal_settings_editable config:type="boolean">true</proposal_settings_editable>
-      </proposal>
+    <ui_mode>simple</ui_mode>
+</globals>
+
+<partitioning>
+    <expert_partitioner_warning config:type="boolean">false</expert_partitioner_warning>
+
+    <proposal>
+        <lvm config:type="boolean">false</lvm>
+        <proposal_settings_editable config:type="boolean">true</proposal_settings_editable>
+    </proposal>
 
       <volumes config:type="list">
           <!-- / volume: 3 GiB - 10 GiB, *4 if snapshots are used -->

--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -36,15 +36,15 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
     <dhclient_set_hostname config:type="boolean">false</dhclient_set_hostname>
 
     <ui_mode>simple</ui_mode>
-</globals>
+  </globals>
 
-<partitioning>
-    <expert_partitioner_warning config:type="boolean">false</expert_partitioner_warning>
+  <partitioning>
+      <expert_partitioner_warning config:type="boolean">false</expert_partitioner_warning>
 
-    <proposal>
-        <lvm config:type="boolean">false</lvm>
-        <proposal_settings_editable config:type="boolean">true</proposal_settings_editable>
-    </proposal>
+      <proposal>
+          <lvm config:type="boolean">false</lvm>
+          <proposal_settings_editable config:type="boolean">true</proposal_settings_editable>
+      </proposal>
 
       <volumes config:type="list">
           <!-- / volume: 3 GiB - 10 GiB, *4 if snapshots are used -->

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr 16 04:10:11 UTC 2018 - jreidinger@suse.com
+
+- Add missing globals that is different to SLES (bsc#1089516)
+- 15.0.19
+
+-------------------------------------------------------------------
 Wed Mar 26 14:32:55 UTC 2018 - rbrown@suse.com
 
 - Create /root subvolume on fresh installs (bsc#1085266)

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Apr 16 04:10:11 UTC 2018 - jreidinger@suse.com
 
-- Add missing globals that is different to SLES (bsc#1089516)
+- Add missing globals that are different to SLES (bsc#1089516)
 - 15.0.19
 
 -------------------------------------------------------------------

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -90,7 +90,7 @@ Provides:       system-installation() = SLED
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        15.0.18
+Version:        15.0.19
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
Add missing globals (bsc#1089516)

This bug was introduced during split where globals was not added to
SLED. Leanos uses SLES globals, so we need to re-add only differences to
SLES.