### PR TITLE
Fixed the default self_update URL for SP5 (bsc#1152275)

### DIFF
--- a/control/control.SLED.xml
+++ b/control/control.SLED.xml
@@ -79,7 +79,7 @@ textdomain="control"
         </services_proposal>
 
 	<!-- self-update URL -->
-	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-DESKTOP-INSTALLER/12-SP3/$arch/update</self_update_url>
+	<self_update_url>https://updates.suse.com/SUSE/Updates/SLE-DESKTOP-INSTALLER/12-SP5/$arch/update</self_update_url>
     </globals>
 
     <software>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 27 11:28:21 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed the default self_update URL for SP5 (bsc#1152275)
+- 12.5.0
+
+-------------------------------------------------------------------
 Wed Apr 26 10:19:04 CEST 2017 - schubi@suse.de
 
 - Added yast2-configuration-management to inst-sys.

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -89,7 +89,7 @@ Requires:  yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        12.3.4
+Version:        12.5.0
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
- Similar to https://github.com/yast/skelcd-control-SLES/pull/127
- 12.5.0