### PR TITLE
Run the registration also on the Full medium (jsc#SLE-7214)

### DIFF
--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -188,11 +188,9 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
                     <enable_back>yes</enable_back>
                     <enable_next>yes</enable_next>
                     <!-- Skip the registration on the new online medium (already registered
-                         at this point) and offline medium (registration not required). -->
-                    <!-- TODO: Remove this step completely once the old Installer and
-                         Packages DVD are dropped. -->
+                         at this point) -->
                     <arguments>
-                      <skip>online,offline</skip>
+                      <skip>online</skip>
                     </arguments>
                 </module>
                 <module>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec  4 17:58:23 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Run the registration also on the Full medium (jsc#SLE-7214)
+- 15.2.1
+
+-------------------------------------------------------------------
 Thu Oct 17 10:12:35 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
 
 - Skip the registration step on the online and offline installation

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -93,7 +93,7 @@ Provides:       system-installation() = SLED
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        15.2.0
+Version:        15.2.1
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
## Problem

- The request is to also allow registering when using the Full installation medium

## Fix

- Enable the registration step on the Full medium
- Removed that obsolete comment
- This is similar to https://github.com/yast/skelcd-control-SLES/pull/128