### PR TITLE
Preselected modules in offline installation

### DIFF
--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -26,6 +26,17 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
       </roles_help>
   </texts>
 
+  <software>
+    <!-- the default preselected modules in offline installation -->
+    <default_modules config:type="list">
+        <default_module>sle-module-basesystem</default_module>
+        <default_module>sle-module-desktop-applications</default_module>
+        <default_module>sle-module-python2</default_module>
+        <default_module>sle-module-web-scripting</default_module>
+        <default_module>sle-we</default_module>
+    </default_modules>
+  </software>
+
   <globals>
     <!-- bsc #1058672: Unset /etc/sysconfig/security/POLKIT_DEFAULT_PRIVS -->
     <polkit_default_privs><![CDATA[]]></polkit_default_privs>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Feb 25 11:29:57 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added default preselected modules in offline installation
+  (jsc#SLE-8040)
+- 15.2.2
+
+-------------------------------------------------------------------
 Wed Dec  4 17:58:23 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Run the registration also on the Full medium (jsc#SLE-7214)

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -34,8 +34,8 @@ Summary:        SLED control file needed for installation
 License:        MIT
 Group:          Metapackages
 BuildRequires:  libxml2-tools
-# Added skelcd macros
-BuildRequires:  yast2-installation-control >= 4.1.5
+# Added software/default_modules
+BuildRequires:  yast2-installation-control >= 4.2.9
 
 ######################################################################
 #
@@ -93,7 +93,7 @@ Provides:       system-installation() = SLED
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        15.2.1
+Version:        15.2.2
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
- Added the default preselected modules in offline installation
- Related to https://jira.suse.com/browse/SLE-8040 and https://jira.suse.com/browse/SLE-11455
- From JIRA: SLED: Basesystem, Workstation Extension, Desktop Applications, Web&Scripting, Python
- 15.2.2