### PR TITLE
Do not preselect the "Web and Scripting" module (bsc#1165634)

### DIFF
--- a/control/installation.SLED.xml
+++ b/control/installation.SLED.xml
@@ -32,7 +32,6 @@ defined by a role can be overridden in the next steps if necessary.&lt;/p&gt;</l
         <default_module>sle-module-basesystem</default_module>
         <default_module>sle-module-desktop-applications</default_module>
         <default_module>sle-module-python2</default_module>
-        <default_module>sle-module-web-scripting</default_module>
         <default_module>sle-we</default_module>
     </default_modules>
   </software>

--- a/package/skelcd-control-SLED.changes
+++ b/package/skelcd-control-SLED.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Mar  4 08:41:39 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
+
+- Do not preselect the "Web and Scripting" module in offline
+  installation (bsc#1165634)
+- 15.2.3
+
+-------------------------------------------------------------------
 Tue Feb 25 11:29:57 UTC 2020 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added default preselected modules in offline installation

--- a/package/skelcd-control-SLED.spec
+++ b/package/skelcd-control-SLED.spec
@@ -93,7 +93,7 @@ Provides:       system-installation() = SLED
 
 Url:            https://github.com/yast/skelcd-control-SLED
 AutoReqProv:    off
-Version:        15.2.2
+Version:        15.2.3
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source:         %{name}-%{version}.tar.bz2


### PR DESCRIPTION
- Do not preselect the "Web and Scripting" modulein offline installation
- There was a mistake in the original [SLE-8040](https://jira.suse.com/browse/SLE-8040) specification
- 15.2.3